### PR TITLE
Patch fixes

### DIFF
--- a/workflow/background.py
+++ b/workflow/background.py
@@ -96,9 +96,9 @@ def _job_pid(name):
 
     with open(pidfile, "rb") as fp:
         read = fp.read()
-        print(str(read))
+        # print(str(read))
         pid = int.from_bytes(read, sys.byteorder)
-        print(pid)
+        # print(pid)
 
         if _process_exists(pid):
             return pid
@@ -235,7 +235,7 @@ def run_in_background(name, args, **kwargs):
     # Call this script
     cmd = [sys.executable, "-m", "workflow.background", name]
     _log().debug("[%s] passing job to background runner: %r", name, cmd)
-    retcode = subprocess.call(cmd, env={"PYTHONPATH": ":".join(sys.path)})
+    retcode = subprocess.call(cmd)
 
     if retcode:  # pragma: no cover
         _log().error("[%s] background runner failed with %d", name, retcode)

--- a/workflow/update.py
+++ b/workflow/update.py
@@ -30,8 +30,7 @@ import tempfile
 from collections import defaultdict
 from functools import total_ordering
 from itertools import zip_longest
-
-import requests
+from urllib import request
 
 from workflow.util import atomic_writer
 
@@ -389,11 +388,10 @@ def retrieve_download(dl):
     path = os.path.join(tempfile.gettempdir(), dl.filename)
     wf().logger.debug("downloading update from " "%r to %r ...", dl.url, path)
 
-    r = requests.get(dl.url)
-    r.raise_for_status()
+    r = request.urlopen(dl.url)
 
     with atomic_writer(path, "wb") as file_obj:
-        file_obj.write(r.content)
+        file_obj.write(r.read())
 
     return path
 
@@ -429,9 +427,8 @@ def get_downloads(repo):
 
     def _fetch():
         wf().logger.info("retrieving releases for %r ...", repo)
-        r = requests.get(url)
-        r.raise_for_status()
-        return r.content
+        r = request.urlopen(url)
+        return r.read()
 
     key = "github-releases-" + repo.replace("/", "-")
     js = wf().cached_data(key, _fetch, max_age=60)


### PR DESCRIPTION
Here are some editing that fix for me in my workflow [Coinc](https://github.com/tomy0000000/Coinc), listed as follow:

* Comment out debug print, as those interfere workflow's send feedback, use logger to debug
* Remove the explicit env assignment for subprocess calling, as those are not necessary and wipe of Alfred ENVs in the subprocess
* Use the builtin `urllib` instead of `requests`
  * I dropped the `raise_for_status` call, since it's an implicit default behavior in `urllib.urlopen`

Unlike most developer expected, I strongly discourage using any additional modules in workflow. As the installation gets very complicated for user that does not have adequate knowledge in dev. The worst scenario would be having multiple python instances of Python installed on device, and we have no clue of which `pip` is the user exactly using. Such cases are hard to diagnose and as workflow author, I wouldn't want to waste my time on solving this kind of environmental issues for user.