### PR TITLE
Fix Background Tasks (Python3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ info.plist
 
 
 temp_*.py
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.1.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -8,7 +8,7 @@ repos:
       - id: check-executables-have-shebangs
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
@@ -19,18 +19,31 @@ repos:
   #     - id: mypy
   #       exclude: extras|^docs/conf.py
 
-  - repo: https://github.com/prettier/prettier
-    rev: 1.19.1
-    hooks:
-      - id: prettier
-        args: [--prose-wrap=always, --print-width=88]
+#
+#  - repo: https://github.com/prettier/prettier
+#    rev: 1.19.1
+#    hooks:
+#      - id: prettier#
+  ##  - repo: https://github.com/prettier/prettier
+  ##    rev: 1.19.1
+  ##    hooks:
+  ##      - id: prettier
+  ##        args: [--prose-wrap=always, --print-width=88]
+#        args: [--prose-wrap=always, --print-width=88]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.5.2
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 22.3.0
     hooks:
       - id: black
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v0.942
+  #   hooks:
+  #     - id: mypy
+  #       exclude: extras|^docs/conf.py|bin|tests
+  #       types:
+  #         - python

--- a/workflow/background.py
+++ b/workflow/background.py
@@ -18,12 +18,7 @@ and examples.
 
 
 import os
-
-try:
-    import cPickle as pickle
-except:
-    import pickle
-
+import pickle
 import signal
 import subprocess
 import sys

--- a/workflow/background.py
+++ b/workflow/background.py
@@ -18,7 +18,12 @@ and examples.
 
 
 import os
-import pickle
+
+try:
+    import cPickle as pickle
+except:
+    import pickle
+
 import signal
 import subprocess
 import sys

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -1267,7 +1267,7 @@ class Workflow(object):
         """Alfred 2's default cache directory."""
         return os.path.join(
             os.path.expanduser(
-                "~/Library/Caches/com.runningwithcrayons.Alfred-2/" "Workflow Data/"
+                "~/Library/Caches/com.runningwithcrayons.Alfred/" "Workflow Data/"
             ),
             self.bundleid,
         )
@@ -1605,8 +1605,6 @@ class Workflow(object):
                 "to load this data.".format(serializer_name)
             )
 
-        self.logger.debug("data `%s` stored as `%s`", name, serializer_name)
-
         filename = "{0}.{1}".format(name, serializer_name)
         data_path = self.datafile(filename)
 
@@ -1677,9 +1675,6 @@ class Workflow(object):
             delete_paths((metadata_path, data_path))
             return
 
-        if isinstance(data, str):
-            data = bytearray(data, encoding="utf-8")
-
         # Ensure write is not interrupted by SIGTERM
         @uninterruptible
         def _store():
@@ -1691,8 +1686,6 @@ class Workflow(object):
                 serializer.dump(data, file_obj)
 
         _store()
-
-        self.logger.debug("saved data: %s", data_path)
 
     def cached_data(self, name, data_func=None, max_age=60):
         """Return cached data if younger than ``max_age`` seconds.

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -25,12 +25,7 @@ import json
 import logging
 import logging.handlers
 import os
-
-try:
-    import cPickle as pickle
-except:
-    import pickle
-
+import pickle
 import plistlib
 import re
 import shutil
@@ -693,7 +688,6 @@ class PickleSerializer(BaseSerializer):
 
 # Set up default manager and register built-in serializers
 manager = SerializerManager()
-manager.register("cpickle", PickleSerializer)
 manager.register("pickle", PickleSerializer)
 manager.register("json", JSONSerializer)
 
@@ -1605,6 +1599,8 @@ class Workflow(object):
                 "to load this data.".format(serializer_name)
             )
 
+        self.logger.debug("data `%s` stored as `%s`", name, serializer_name)
+
         filename = "{0}.{1}".format(name, serializer_name)
         data_path = self.datafile(filename)
 
@@ -1617,6 +1613,8 @@ class Workflow(object):
 
         with open(data_path, "rb") as file_obj:
             data = serializer.load(file_obj)
+
+        self.logger.debug("stored data loaded: %s", data_path)
 
         return data
 
@@ -1686,6 +1684,8 @@ class Workflow(object):
                 serializer.dump(data, file_obj)
 
         _store()
+
+        self.logger.debug("saved data: %s", data_path)
 
     def cached_data(self, name, data_func=None, max_age=60):
         """Return cached data if younger than ``max_age`` seconds.

--- a/workflow/workflow.py
+++ b/workflow/workflow.py
@@ -25,7 +25,12 @@ import json
 import logging
 import logging.handlers
 import os
-import pickle
+
+try:
+    import cPickle as pickle
+except:
+    import pickle
+
 import plistlib
 import re
 import shutil
@@ -688,6 +693,7 @@ class PickleSerializer(BaseSerializer):
 
 # Set up default manager and register built-in serializers
 manager = SerializerManager()
+manager.register("cpickle", PickleSerializer)
 manager.register("pickle", PickleSerializer)
 manager.register("json", JSONSerializer)
 
@@ -1614,8 +1620,6 @@ class Workflow(object):
         with open(data_path, "rb") as file_obj:
             data = serializer.load(file_obj)
 
-        self.logger.debug("stored data loaded: %s", data_path)
-
         return data
 
     def store_data(self, name, data, serializer=None):
@@ -1674,7 +1678,7 @@ class Workflow(object):
             return
 
         if isinstance(data, str):
-            data = bytearray(data)
+            data = bytearray(data, encoding="utf-8")
 
         # Ensure write is not interrupted by SIGTERM
         @uninterruptible


### PR DESCRIPTION
I made a few changes here mostly dealing with pickle / cpickle and how python3 handles strings. Local testing seems to fix some of the issues I was seeing - which in summary are the following:


* Default CacheDIR wasn't being picked up by background process - so I just got rid of the Alfred 2 version and moved to the Alfred 4
* There were issues with how strings were getting encoded relating to Python3 - removed string-specific logic and pickle now seems to handle them fine.

_I also updated the pre-commit hooks to add Mypy - but realized thats WAY too much for this PR so its commented out._

Using these changes I got my emoji plugin downloading files again with reporting:

<img width="383" alt="image" src="https://user-images.githubusercontent.com/6491743/161798453-b67ec751-d06b-4234-822c-6b992167dcc0.png">
